### PR TITLE
Expand Resize Event Bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "object-assign": "^1.0.0"
   },
   "devDependencies": {
-    "react": "^0.12.0"
+    "react": ">=0.12.0"
   },
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": ">=0.12.0"
   }
 }

--- a/src/component.js
+++ b/src/component.js
@@ -41,7 +41,7 @@ var Resizeable = React.createClass({
   resetTriggers: function () {
     var contract = this.refs.contract.getDOMNode();
     var expandChild = this.refs.expandChild.getDOMNode();
-    var expand = this.refs.expandChild.getDOMNode();
+    var expand = this.refs.expand.getDOMNode();
 
     contract.scrollLeft      = contract.scrollWidth;
     contract.scrollTop       = contract.scrollHeight;


### PR DESCRIPTION
-found an issue where the component would not fire resize events when expanding. The issue seems to have been a typo in the resetTriggers function

-tested this with react 13